### PR TITLE
Specify `Include` of default.yml in one place

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,23 +1,19 @@
+Rake:
+  Include:
+    - 'Rakefile'
+    - '**/*.rake'
+
 Rake/ClassDefinitionInTask:
   Description: 'Do not define a class or module in rake task, because it will be defined to the top level.'
   Enabled: true
   VersionAdded: '0.3.0'
-  Include:
-    - 'Rakefile'
-    - '**/*.rake'
 
 Rake/Desc:
   Description: 'Describe the task with `desc` method.'
   Enabled: true
   VersionAdded: '0.1.0'
-  Include:
-    - 'Rakefile'
-    - '**/*.rake'
 
 Rake/MethodDefinitionInTask:
   Description: 'Do not define a method in rake task, because it will be defined to the top level.'
   Enabled: true
   VersionAdded: '0.2.0'
-  Include:
-    - 'Rakefile'
-    - '**/*.rake'


### PR DESCRIPTION
This PR specifies `Include` of default.yml in one place. I think that it can be specified in one place because RuboCop Rake is specialized in Rake.