### PR TITLE
Add `Enabled: true` to `Rake` department config

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,4 +1,5 @@
 Rake:
+  Enabled: true
   Include:
     - 'Rakefile'
     - '**/*.rake'


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop-minitest/issues/25#issuecomment-543504420.

This PR adds `Enabled: true` to `Rake` department config. It resolves the following warning:

```yaml
# .rubocop.yml
require: rubocop-rake

AllCops:
  DisabledByDefault: true

Rake:
  Enabled: true
```

```console
% bundle exec rubocop
Warning: Rake does not support Enabled parameter.

Supported parameters are:

  - Include

Inspecting 1 file
.

1 file inspected, no offenses detected
```