### PR TITLE
Update RuboCop to 0.76 for development dependency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ Style/AccessModifierDeclarations:
 Style/NumericPredicate:
   Enabled: false
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Exclude:
     - '*.gemspec'
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem 'rspec'
+gem 'rubocop', '>= 0.76'
 gem 'rubocop-rspec'


### PR DESCRIPTION
Because Style/UnneededPersentQ is renamed to RedundantPercentQ