### PR TITLE
Update `LineLength` cop in .rubocop.yml to `Layout` department

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ require:
 AllCops:
   TargetRubyVersion: 2.4
 
+Layout/LineLength:
+  Enabled: false
+
 Metrics:
   Enabled: false
 


### PR DESCRIPTION
This PR suppress the following RuboCop's offenses.

```console
% cd path/to/repo/rubocop-rake
% bundle exec rake
rubocop
Inspecting 25 files
....C.CC.....C....C..CC..

Offenses:

lib/rubocop/cop/rake/class_definition_in_task.rb:32:81: C:
Layout/LineLength: Line is too long. [99/80]
        MSG = 'Do not define a %<type>s in rake task, because it will be
defined to the top level.'
       ^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/rake/duplicate_namespace.rb:6:81: C: Layout/LineLength:
Line is too long. [87/80]
      # If namespaces are defined with the same name, Rake executes the
both namespaces
        ^^^^^^^
lib/rubocop/cop/rake/duplicate_namespace.rb:33:81: C: Layout/LineLength:
Line is too long. [90/80]
        MSG = 'Namespace `%<namespace>s` is defined at both %<previous>s
and %<current>s.'
       ^^^^^^^^^^
lib/rubocop/cop/rake/duplicate_namespace.rb:46:81: C: Layout/LineLength:
Line is too long. [94/80]
            message = message_for_dup(previous: previous, current: node,
namespace: full_name)
       ^^^^^^^^^^^^^^
lib/rubocop/cop/rake/duplicate_task.rb:45:81: C: Layout/LineLength: Line
is too long. [94/80]
            message = message_for_dup(previous: previous, current: node,
task_name: full_name)
       ^^^^^^^^^^^^^^
lib/rubocop/cop/rake/method_definition_in_task.rb:34:81: C:
Layout/LineLength: Line is too long. [97/80]
        MSG = 'Do not define a method in rake task, because it will be
defined to the top level.'
         ^^^^^^^^^^^^^^^^^
rubocop-rake.gemspec:24:81: C: Layout/LineLength: Line is too
long. [87/80]
  # The `git ls-files -z` loads the files in the RubyGem that have been
added into git.
        ^^^^^^^
rubocop-rake.gemspec:26:81: C: Layout/LineLength: Line is too
long. [85/80]
    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|
features)/}) }
         ^^^^^
spec/rubocop/cop/rake/duplicate_namespace_spec.rb:63:81: C:
Layout/LineLength: Line is too long. [88/80]
  it 'does not register an offense with the same name but in the
different namespace' do
               ^^^^^^^^
spec/rubocop/cop/rake/duplicate_task_spec.rb:74:81: C:
Layout/LineLength: Line is too long. [88/80]
  it 'does not register an offense with the same name but in the
different namespace' do
               ^^^^^^^^

25 files inspected, 10 offenses detected
rake aborted!
Command failed with status (1): [rubocop...]
/Users/koic/src/github.com/rubocop-hq/rubocop-rake/Rakefile:36:in `block
in <top (required)>'
/Users/koic/.rbenv/versions/2.7.0/bin/bundle:23:in `load'
/Users/koic/.rbenv/versions/2.7.0/bin/bundle:23:in `<main>'
Tasks: TOP => default => rubocop
(See full trace by running task with --trace)
```

`LineLength` cop has been moved from `Metrics` department to `Layout` department.

cf. rubocop-hq/rubocop#7542