### PR TITLE
CI against Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,11 @@ jobs:
       - image: circleci/ruby:2.6
     <<: *steps
 
+  ruby-2.7:
+    docker:
+      - image: circleci/ruby:2.7
+    <<: *steps
+
   ruby-head:
     docker:
       - image: rubocophq/circleci-ruby-snapshot:latest
@@ -40,5 +45,5 @@ workflows:
       - ruby-2.3
       - ruby-2.4
       - ruby-2.5
-      - ruby-2.6
+      - ruby-2.7
       - ruby-head


### PR DESCRIPTION
Ruby 2.7.0 has been released and this Ruby version is available on `circleci/ruby:2.7` image.

- https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/
- https://hub.docker.com/r/circleci/ruby/tags/

```console
% docker pull circleci/ruby:2.7
2.7: Pulling from circleci/ruby

(snip)

Status: Downloaded newer image for circleci/ruby:2.7
```