### PR TITLE
Enable CI with Ruby 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,5 +45,6 @@ workflows:
       - ruby-2.3
       - ruby-2.4
       - ruby-2.5
+      - ruby-2.6
       - ruby-2.7
       - ruby-head


### PR DESCRIPTION
A job for Ruby 2.6 is defined, but the workflow does not contain the job.
This pull request will add the job to the workflow.
