### PR TITLE
[Fix #28] Fix `Rake/Desc` to avoid an error when `task` is not a task definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,9 @@
 
 ## master (unreleased)
 
-<!--
-
-### New features
-
 ### Bug fixes
 
-### Changes
-
--->
+* [#28](https://github.com/rubocop-hq/rubocop-rake/issues/28): Fix `Rake/Desc` to avoid an error when `task` is not a task definition. ([@pocke][])
 
 ## 0.5.0 (2019-10-31)
 

--- a/lib/rubocop/cop/rake/desc.rb
+++ b/lib/rubocop/cop/rake/desc.rb
@@ -42,6 +42,7 @@ module RuboCop
         private def task_with_desc?(node)
           parent, task = parent_and_task(node)
           return false unless parent
+          return true unless can_insert_desc_to?(parent)
 
           idx = parent.children.find_index(task) - 1
           desc_candidate = parent.children[idx]
@@ -62,6 +63,10 @@ module RuboCop
             # when something { task }
             [parent, task_node]
           end
+        end
+
+        private def can_insert_desc_to?(parent)
+          parent.begin_type? || parent.block_type? || parent.kwbegin_type?
         end
       end
     end

--- a/spec/rubocop/cop/rake/desc_spec.rb
+++ b/spec/rubocop/cop/rake/desc_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe RuboCop::Cop::Rake::Desc do
     RUBY
   end
 
+  it 'register an offense for task in kwbegin' do
+    expect_offense(<<~RUBY)
+      begin
+        task :foo
+        ^^^^^^^^^ Describe the task with `desc` method.
+      end
+    RUBY
+  end
+
   it 'does not register an offense for task with desc' do
     expect_no_offenses(<<~RUBY)
       desc 'Do foo'
@@ -45,11 +54,17 @@ RSpec.describe RuboCop::Cop::Rake::Desc do
     RUBY
   end
 
-  it 'do not register an offense for the default task' do
+  it 'does not register an offense for the default task' do
     expect_no_offenses(<<~RUBY)
       task default: :spec
 
       task default: [:spec, :rubocop]
+    RUBY
+  end
+
+  it 'does not register an offense when `task` is not a definition' do
+    expect_no_offenses(<<~RUBY)
+      task.name
     RUBY
   end
 end


### PR DESCRIPTION
Fix #28 



