### PR TITLE
Drop support for Ruby 2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,6 @@ steps: &steps
 
 jobs:
 
-  ruby-2.3:
-    docker:
-      - image: circleci/ruby:2.3
-    <<: *steps
-
   ruby-2.4:
     docker:
       - image: circleci/ruby:2.4
@@ -42,7 +37,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - ruby-2.3
       - ruby-2.4
       - ruby-2.5
       - ruby-2.6

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,3 +45,8 @@ RSpec/ExampleLength:
 Naming/FileName:
   Exclude:
     - 'lib/rubocop-rake.rb'
+
+# This disabling is a workaround for https://github.com/rubocop-hq/rubocop-rspec/issues/1068.
+# The cop has been disabled because FactoryBot is not used in this repository.
+RSpec/FactoryBot/CreateList:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#33](https://github.com/rubocop-hq/rubocop-rake/pull/33): Drop support for Ruby 2.3. ([@koic][])
+
 ## 0.5.1 (2020-02-14)
 
 ### Bug fixes
@@ -51,3 +55,4 @@
 
 [@pocke]: https://github.com/pocke
 [@jaruuuu]: https://github.com/jaruuuu
+[@koic]: https://github.com/koic

--- a/rubocop-rake.gemspec
+++ b/rubocop-rake.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{A RuboCop plugin for Rake}
   spec.description   = %q{A RuboCop plugin for Rake}
   spec.homepage      = "https://github.com/rubocop-hq/rubocop-rake"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
   spec.licenses = ['MIT']
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"


### PR DESCRIPTION
This PR drops support for Ruby 2.3 and suppresses the following `Gemspec/RequiredRubyVersion` offense.

```console
% cd path/to/rubocop-rake
% bundle exec rake
(snip)

Offenses:

rubocop-rake.gemspec:14:32: C: Gemspec/RequiredRubyVersion:
required_ruby_version (2.3, declared in rubocop-rake.gemspec) and
TargetRubyVersion (2.4, which may be specified in .rubocop.yml) should
be equal.
  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

25 files inspected, 1 offense detected
```

And this PR fixes the following `RSpec/FactoryBot/CreateList` error.

```console
% cd path/to/rubocop-rake
 bundle exec rake
(snip)

An error occurred while RSpec/FactoryBot/CreateList cop was inspecting
/Users/koic/src/github.com/rubocop-hq/rubocop-rake/spec/spec_helper.rb:15:15.
To see the complete backtrace run rubocop -d.
```