### PR TITLE
Use `Cop::Base` API for `Rake` department

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#33](https://github.com/rubocop-hq/rubocop-rake/pull/33): Drop support for Ruby 2.3. ([@koic][])
+* [#34](https://github.com/rubocop-hq/rubocop-rake/pull/34): Require RuboCop 1.0 or higher. ([@koic][])
 
 ## 0.5.1 (2020-02-14)
 

--- a/lib/rubocop/cop/rake/class_definition_in_task.rb
+++ b/lib/rubocop/cop/rake/class_definition_in_task.rb
@@ -28,18 +28,14 @@ module RuboCop
       #   task :foo do
       #   end
       #
-      class ClassDefinitionInTask < Cop
+      class ClassDefinitionInTask < Base
         MSG = 'Do not define a %<type>s in rake task, because it will be defined to the top level.'
 
         def on_class(node)
           return if Helper::ClassDefinition.in_class_definition?(node)
           return unless Helper::TaskDefinition.in_task_or_namespace?(node)
 
-          add_offense(node)
-        end
-
-        def message(node)
-          format(MSG, type: node.type)
+          add_offense(node, message: format(MSG, type: node.type))
         end
 
         alias on_module on_class

--- a/lib/rubocop/cop/rake/desc.rb
+++ b/lib/rubocop/cop/rake/desc.rb
@@ -27,8 +27,9 @@ module RuboCop
       #   task :do_something do
       #   end
       #
-      class Desc < Cop
+      class Desc < Base
         include Helper::OnTask
+        extend AutoCorrector
 
         MSG = 'Describe the task with `desc` method.'
 

--- a/lib/rubocop/cop/rake/duplicate_namespace.rb
+++ b/lib/rubocop/cop/rake/duplicate_namespace.rb
@@ -27,7 +27,7 @@ module RuboCop
       #     end
       #   end
       #
-      class DuplicateNamespace < Cop
+      class DuplicateNamespace < Base
         include Helper::OnNamespace
 
         MSG = 'Namespace `%<namespace>s` is defined at both %<previous>s and %<current>s.'

--- a/lib/rubocop/cop/rake/duplicate_task.rb
+++ b/lib/rubocop/cop/rake/duplicate_task.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     p 'foo 2'
       #   end
       #
-      class DuplicateTask < Cop
+      class DuplicateTask < Base
         include Helper::OnTask
 
         MSG = 'Task `%<task>s` is defined at both %<previous>s and %<current>s.'

--- a/lib/rubocop/cop/rake/method_definition_in_task.rb
+++ b/lib/rubocop/cop/rake/method_definition_in_task.rb
@@ -30,7 +30,7 @@ module RuboCop
       #   task :foo do
       #   end
       #
-      class MethodDefinitionInTask < Cop
+      class MethodDefinitionInTask < Base
         MSG = 'Do not define a method in rake task, because it will be defined to the top level.'
 
         def on_def(node)

--- a/rubocop-rake.gemspec
+++ b/rubocop-rake.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'rubocop'
+  spec.add_runtime_dependency 'rubocop', '~> 1.0'
 end


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/7868.

This PR uses `Cop::Base` API for `Rake` department's cops.
This repository is not maintained frequently now, so RuboCop Rake dependent on RuboCop 1.0 stable API.